### PR TITLE
Added EKS template for GitLab runners

### DIFF
--- a/templates/eks.yaml
+++ b/templates/eks.yaml
@@ -1,0 +1,66 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Parameters:
+  Prefix:
+    Type: String
+
+  Subnet1:
+    Type: AWS::EC2::Subnet::Id
+    Description: SubnetId for EKS. This has to be in a different AZ from subnet 2.
+    
+  Subnet2:
+    Type: AWS::EC2::Subnet::Id
+    Description: SubnetId for EKS. This has to be in a different AZ from subnet 2.
+      
+  SecurityGroupId:
+    Type: AWS::EC2::SecurityGroup::Id
+    Description: Id of the EKS Security Group. This ia an additional security group to the one created by EKS.
+    
+  EKSClusterIamRoleArn:
+    Type: String
+    Description: IAM Role ARN to associate with EKS instance
+    
+  InstanceTypes:
+    Type: String
+    Description: The instance type to use for your node group
+    Default: t3.medium
+    AllowedValues:
+      - t3.medium
+      - t3.large
+      - m5.large
+      - m5.xlarge
+      - c5.large
+      - c5.xlarge
+
+  EKSNodeGroupIamRoleArn:
+    Type: String
+    Description: IAM Role ARN to associate with EKS node group
+    
+Resources:
+  EksCluster:
+    Type: AWS::EKS::Cluster
+    Properties:
+      Name: !Sub ${Prefix}-eks
+      Version: '1.17'
+      RoleArn: !Ref EKSClusterIamRoleArn
+      ResourcesVpcConfig:
+        SecurityGroupIds:
+          - !Ref SecurityGroupId
+        SubnetIds:
+          - !Ref Subnet1
+          - !Ref Subnet2
+  EKSNodeGroup:
+    Type: AWS::EKS::Nodegroup
+    Properties:
+      ClusterName: !Ref EksCluster
+      InstanceTypes:
+        - !Ref InstanceTypes
+      NodeRole: !Ref EKSNodeGroupIamRoleArn
+      Subnets:
+        - !Ref Subnet1
+        - !Ref Subnet2
+      Version: '1.17'
+      ScalingConfig:
+        DesiredSize: 2
+        MaxSize: 4
+        MinSize: 2

--- a/templates/iam.yaml
+++ b/templates/iam.yaml
@@ -77,3 +77,64 @@ Resources:
       RoleName: !Sub ${Prefix}-general-role
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+
+  EksClusterRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - eks.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      RoleName: !Sub ${Prefix}-eks-role
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+
+  EksNodeGroupRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument: |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ec2.amazonaws.com"
+              },
+              "Action": "sts:AssumeRole"
+            }
+          ]
+        }
+      RoleName: !Sub ${Prefix}-eks-node-group-role
+      Policies:
+        - PolicyName: ${Prefix}-s3
+          PolicyDocument: !Sub |
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": "sts:AssumeRole",
+                        "Resource":  "arn:aws:iam::*:role/${Prefix}-target-role"
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "s3:GetObject",
+                            "s3:ListBucket"
+                        ],
+                        "Resource": "arn:aws:s3:::${Prefix}-*"
+                    }
+                ]
+            }
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser
+        - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly


### PR DESCRIPTION
# Resources added
1. EKS Cluster
2. EKS Node Groups
3. IAM role for EKS Cluster
4. IAM role for EKS Node Groups

# Things to note
1. The ECR Read only is used in the IAM role for the EKS node group can be removed after creation since there is an ECR power user policy attached.